### PR TITLE
Add mobile-friendly controls and progress tracking

### DIFF
--- a/brain/digits/digits-game.js
+++ b/brain/digits/digits-game.js
@@ -1,3 +1,5 @@
+import { addProgress } from '../progress.js';
+
 class DigitsGame extends HTMLElement {
   constructor() {
     super();
@@ -21,6 +23,7 @@ class DigitsGame extends HTMLElement {
         :host {
           display: block;
           max-width: 400px;
+          margin: 0 auto;
         }
         .score {
           margin: 0.5em 0;
@@ -85,6 +88,7 @@ class DigitsGame extends HTMLElement {
     const value = this.answerField.value.trim();
     if (value === this.sequence) {
       this.score++;
+      addProgress();
       this.round++;
       this.updateScore();
       this.nextRound();

--- a/brain/digits/index.html
+++ b/brain/digits/index.html
@@ -10,6 +10,7 @@
 <body>
   <h1>Digits Memory Game</h1>
   <digits-game></digits-game>
+  <p><a href="../index.html"><button>Back</button></a></p>
   <script type="module" src="digits-game.js"></script>
 </body>
 </html>

--- a/brain/progress-calendar.js
+++ b/brain/progress-calendar.js
@@ -1,0 +1,25 @@
+import { getProgress } from './progress.js';
+
+class ProgressCalendar extends HTMLElement {
+  connectedCallback() {
+    this.render();
+  }
+
+  render() {
+    const data = getProgress();
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = now.getMonth();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    let html = '<div class="calendar">';
+    for (let d = 1; d <= daysInMonth; d++) {
+      const date = new Date(year, month, d).toISOString().slice(0, 10);
+      const count = data[date] || 0;
+      html += `<div class="day"><span class="num">${d}</span><span class="count">${count}</span></div>`;
+    }
+    html += '</div>';
+    this.innerHTML = html;
+  }
+}
+
+customElements.define('progress-calendar', ProgressCalendar);

--- a/brain/progress.js
+++ b/brain/progress.js
@@ -1,0 +1,12 @@
+export function addProgress() {
+  const key = 'progress';
+  const data = JSON.parse(localStorage.getItem(key) || '{}');
+  const today = new Date().toISOString().slice(0, 10);
+  data[today] = (data[today] || 0) + 1;
+  localStorage.setItem(key, JSON.stringify(data));
+}
+
+export function getProgress() {
+  const key = 'progress';
+  return JSON.parse(localStorage.getItem(key) || '{}');
+}

--- a/brain/sequence/index.html
+++ b/brain/sequence/index.html
@@ -10,6 +10,7 @@
 <body>
   <h1>Sequence Game</h1>
   <sequence-game></sequence-game>
+  <p><a href="../index.html"><button>Back</button></a></p>
   <script type="module" src="sequence-game.js"></script>
 </body>
 </html>

--- a/brain/sequence/sequence-game.js
+++ b/brain/sequence/sequence-game.js
@@ -1,3 +1,4 @@
+import { addProgress } from '../progress.js';
 const tones = [220, 247, 262, 294, 330, 349, 392, 440, 494];
 
 class SequenceGame extends HTMLElement {
@@ -23,6 +24,7 @@ class SequenceGame extends HTMLElement {
         :host {
           display: block;
           max-width: 400px;
+          margin: 0 auto;
         }
         .score {
           margin: 0.5em 0;
@@ -57,7 +59,7 @@ class SequenceGame extends HTMLElement {
     `;
     this.shadowRoot
       .querySelectorAll('.cell')
-      .forEach((c) => c.addEventListener('click', (e) => this.handleClick(e)));
+      .forEach((c) => c.addEventListener('pointerdown', (e) => this.handleClick(e)));
   }
 
   start() {
@@ -106,6 +108,7 @@ class SequenceGame extends HTMLElement {
     }
     if (this.userInput.length === this.sequence.length) {
       this.score++;
+      addProgress();
       this.updateScore();
       this.nextRound();
     }
@@ -118,10 +121,10 @@ class SequenceGame extends HTMLElement {
       localStorage.setItem('sequence-best', this.best);
       this.shadowRoot.getElementById('best').textContent = this.best;
     }
-    msg.textContent = 'Wrong! Click to restart.';
+    msg.textContent = 'Wrong! Tap a cell to restart.';
     this.shadowRoot.querySelectorAll('.cell').forEach((c) => {
       c.addEventListener(
-        'click',
+        'pointerdown',
         () => {
           msg.textContent = '';
           this.start();

--- a/brain/settings.html
+++ b/brain/settings.html
@@ -9,13 +9,26 @@
 </head>
 <body>
   <h1>Settings</h1>
-  <p>
-    <button id="theme-toggle">Toggle Theme</button>
-  </p>
+  <div class="toggle-wrapper">
+    <div id="theme-toggle" class="toggle"><div class="handle"></div></div>
+  </div>
+  <h2>Progress</h2>
+  <progress-calendar></progress-calendar>
   <p><a href="index.html"><button>Back</button></a></p>
   <script type="module">
     import { toggleTheme } from './theme.js';
-    document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+    import './progress-calendar.js';
+    const toggleEl = document.getElementById('theme-toggle');
+    function syncToggle() {
+      const current = document.documentElement.getAttribute('data-theme') || 'light';
+      if (current === 'dark') toggleEl.classList.add('on');
+      else toggleEl.classList.remove('on');
+    }
+    toggleEl.addEventListener('click', () => {
+      toggleTheme();
+      toggleEl.classList.toggle('on');
+    });
+    syncToggle();
   </script>
 </body>
 </html>

--- a/brain/shapes/index.html
+++ b/brain/shapes/index.html
@@ -10,6 +10,7 @@
 <body>
   <h1>Shapes Memory Game</h1>
   <shapes-game></shapes-game>
+  <p><a href="../index.html"><button>Back</button></a></p>
   <script type="module" src="shapes-game.js"></script>
 </body>
 </html>

--- a/brain/shapes/shapes-game.js
+++ b/brain/shapes/shapes-game.js
@@ -1,3 +1,4 @@
+import { addProgress } from '../progress.js';
 const tones = [220, 247, 262, 294, 330];
 
 class ShapesGame extends HTMLElement {
@@ -19,16 +20,16 @@ class ShapesGame extends HTMLElement {
   render() {
     this.shadowRoot.innerHTML = `
       <style>
-        :host { display:block; max-width:400px; }
+        :host { display:block; max-width:400px; margin:0 auto; }
         .score { margin:0.5em 0; }
         .sequence { min-height:80px; margin:1em 0; }
         .shapes { display:flex; justify-content:space-around; }
         .shape { width:40px; height:40px; cursor:pointer; }
-        .circle { border-radius:50%; background:var(--accent-color); }
-        .square { background:var(--accent-color); }
-        .triangle { width:0; height:0; border-left:20px solid transparent; border-right:20px solid transparent; border-bottom:40px solid var(--accent-color); }
-        .star { color:var(--accent-color); font-size:40px; line-height:40px; }
-        .diamond { transform:rotate(45deg); background:var(--accent-color); width:28px; height:28px; margin-top:6px; }
+        .circle { border-radius:50%; background:#e74c3c; }
+        .square { background:#3498db; }
+        .triangle { width:0; height:0; border-left:20px solid transparent; border-right:20px solid transparent; border-bottom:40px solid #f1c40f; }
+        .star { color:#9b59b6; font-size:40px; line-height:40px; }
+        .diamond { transform:rotate(45deg); background:#2ecc71; width:28px; height:28px; margin-top:6px; }
       </style>
       <div class="score">Score: <span id="score">0</span> | Best: <span id="best">${this.best}</span></div>
       <div class="sequence" id="display"></div>
@@ -41,7 +42,7 @@ class ShapesGame extends HTMLElement {
       </div>
       <div class="message" id="message"></div>
     `;
-    this.shadowRoot.querySelectorAll('.shape').forEach(el => el.addEventListener('click', e => this.handleClick(e)));
+    this.shadowRoot.querySelectorAll('.shape').forEach(el => el.addEventListener('pointerdown', e => this.handleClick(e)));
   }
 
   start() {
@@ -84,6 +85,7 @@ class ShapesGame extends HTMLElement {
     }
     if (this.userInput.length === this.sequence.length) {
       this.score++;
+      addProgress();
       this.updateScore();
       this.nextRound();
     }
@@ -108,10 +110,10 @@ class ShapesGame extends HTMLElement {
       this.best = this.score;
       localStorage.setItem('shapes-best', this.best);
     }
-    msg.textContent = 'Wrong! Click any shape to restart.';
+    msg.textContent = 'Wrong! Tap a shape to restart.';
     this.shadowRoot.getElementById('best').textContent = this.best;
     this.shadowRoot.querySelectorAll('.shape').forEach(el => {
-      el.addEventListener('click', () => {
+      el.addEventListener('pointerdown', () => {
         msg.textContent = '';
         this.start();
       }, { once: true });

--- a/brain/style.css
+++ b/brain/style.css
@@ -17,6 +17,11 @@ body {
   text-align: center;
   background: var(--bg-color);
   color: var(--text-color);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
 button {
@@ -33,4 +38,47 @@ button {
 button:disabled {
   opacity: 0.6;
   cursor: default;
+}
+
+.toggle {
+  width: 40px;
+  height: 20px;
+  border-radius: 10px;
+  background: #ccc;
+  position: relative;
+  margin: 0.5em auto;
+}
+.toggle .handle {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  transition: left 0.2s;
+}
+.toggle.on {
+  background: var(--accent-color);
+}
+.toggle.on .handle {
+  left: 21px;
+}
+
+.calendar {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+  max-width: 280px;
+  margin: 0 auto 1em;
+}
+.calendar .day {
+  border: 1px solid var(--accent-color);
+  padding: 4px;
+  border-radius: 4px;
+  font-size: 0.8em;
+}
+.calendar .count {
+  display: block;
+  font-weight: bold;
 }


### PR DESCRIPTION
## Summary
- center layouts with flexbox
- add progress tracking module and calendar view
- style theme toggle as a slider
- enable pointer events for sequence and shapes games
- assign unique colors to each shape
- record progress after each successful round
- add back navigation links to games

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6847a531b2348323a8e5fdc38eeaf0c6